### PR TITLE
Converted interview template to markdown

### DIFF
--- a/unicef/templates/preliminary-interview-template.md
+++ b/unicef/templates/preliminary-interview-template.md
@@ -1,0 +1,98 @@
+![License: CC BY-SA
+4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)
+
+This document is used as a reference when conducting interviews with the
+[UNICEF Innovation Fund](https://unicefinnovationfund.org/) cohorts. The
+interviews help us collect background and context for each team’s
+experience and familiarity with open source and participating in open
+source communities. This template provides some structure and guidance
+on what questions to ask and understand about each team.
+
+Current situation
+=================
+
+This section helps us understand where each team is at the moment.
+
+1.  What is your product elevator pitch? (i.e. describe project in 2-3
+    sentences)
+
+2.  What milestones are you currently working towards?
+
+3.  How much of your project is currently open source?
+
+4.  If you could grade how well your team does open source, what grade
+    would you give yourself and why?
+
+5.  Any open source challenges that are already on your mind?
+
+6.  How many people on your team have prior experience with open source
+    development?
+
+7.  Do you have an upstream and/or user community?
+
+Project management
+==================
+
+This section helps us understand how each team manages their project
+work and what methods/practices they use.
+
+1.  Do you use a project management method like waterfall or agile?
+
+2.  Do you hold daily or weekly meetings to track progress with the core
+    development team?
+
+3.  Are these meetings or meeting notes recorded anywhere?
+
+4.  What tools do you currently use for project management (e.g.
+    Trello)?
+
+Testing / code health
+=====================
+
+This section helps us understand how each team is writing code and if
+they are in a habit of writing tests for their code. Writing tests is
+important because this supports other ways to grow a community of people
+around the project later. Tests enable others to make small changes to a
+project and feel confident that their change works as expected before
+they submit a contribution. It also supports using other tools like
+continuous integration or test gating.
+
+1.  Do core developers regularly write unit or functional tests?
+
+2.  About what percentage of your code base is tested?
+
+3.  What testing framework is used?
+
+4.  Do you use any code health checking tools in your current workflow?
+
+5.  Did you receive peer reviews on your code base in the last three
+    months by someone outside of your organization?
+
+6.  Do you use any automation tools to deploy your project? (e.g.
+    Ansible, Chef, Docker containers, etc.)
+
+Documentation
+=============
+
+This section helps us understand the documentation culture within each
+cohort. Some teams may do this better than others, and these questions
+help us evaluate where each team is in terms of writing great
+documentation.
+
+1.  Do all open source repositories have a README with an explanation of
+    what the project does and why?
+
+2.  Do any projects have a written, documented guide that explain how to
+    create a development environment?
+
+Miscellaneous
+=============
+
+This can be any questions we think are worth asking but don’t fit into
+another category.
+
+1.  What would need to happen for you to focus more on improving the
+    transparency and open source community of your project?
+
+2.  What does success look like in a world where you have released your
+    project as open source?

--- a/unicef/templates/preliminary-interview-template.md
+++ b/unicef/templates/preliminary-interview-template.md
@@ -1,98 +1,77 @@
 ![License: CC BY-SA
 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)
 
-This document is used as a reference when conducting interviews with the
-[UNICEF Innovation Fund](https://unicefinnovationfund.org/) cohorts. The
-interviews help us collect background and context for each team’s
-experience and familiarity with open source and participating in open
-source communities. This template provides some structure and guidance
-on what questions to ask and understand about each team.
+This document is used as a reference when conducting interviews with the [UNICEF Innovation Fund](https://unicefinnovationfund.org/) cohorts.
+The interviews help us collect background and context for each team’s experience and familiarity with open source and participating in open source communities.
+This template provides some structure and guidance on what questions to ask and understand about each team.
 
 Current situation
-=================
+-----------------
 
 This section helps us understand where each team is at the moment.
 
-1.  What is your product elevator pitch? (i.e. describe project in 2-3
-    sentences)
+**What is your product elevator pitch? (i.e. describe project in 2-3 sentences)**
 
-2.  What milestones are you currently working towards?
+**What milestones are you currently working towards?**
 
-3.  How much of your project is currently open source?
+**How much of your project is currently open source?**
 
-4.  If you could grade how well your team does open source, what grade
-    would you give yourself and why?
+**If you could grade how well your team does open source, what grade would you give yourself and why?**
 
-5.  Any open source challenges that are already on your mind?
+**Any open source challenges that are already on your mind?**
 
-6.  How many people on your team have prior experience with open source
-    development?
+**How many people on your team have prior experience with open source development?**
 
-7.  Do you have an upstream and/or user community?
+**Do you have an upstream and/or user community?**
 
 Project management
-==================
+------------------
 
-This section helps us understand how each team manages their project
-work and what methods/practices they use.
+This section helps us understand how each team manages their project work and what methods/practices they use.
 
-1.  Do you use a project management method like waterfall or agile?
+**Do you use a project management method like waterfall or agile?**
 
-2.  Do you hold daily or weekly meetings to track progress with the core
-    development team?
+**Do you hold daily or weekly meetings to track progress with the core development team?**
 
-3.  Are these meetings or meeting notes recorded anywhere?
+**Are these meetings or meeting notes recorded anywhere?**
 
-4.  What tools do you currently use for project management (e.g.
-    Trello)?
+**What tools do you currently use for project management (e.g. Trello)?**
 
 Testing / code health
-=====================
+---------------------
 
-This section helps us understand how each team is writing code and if
-they are in a habit of writing tests for their code. Writing tests is
-important because this supports other ways to grow a community of people
-around the project later. Tests enable others to make small changes to a
-project and feel confident that their change works as expected before
-they submit a contribution. It also supports using other tools like
-continuous integration or test gating.
+This section helps us understand how each team is writing code and if they are in a habit of writing tests for their code.
+Writing tests is important because this supports other ways to grow a community of people around the project later.
+Tests enable others to make small changes to a project and feel confident that their change works as expected before they submit a contribution.
+It also supports using other tools like continuous integration or test gating.
 
-1.  Do core developers regularly write unit or functional tests?
+**Do core developers regularly write unit or functional tests?**
 
-2.  About what percentage of your code base is tested?
+**About what percentage of your code base is tested?**
 
-3.  What testing framework is used?
+**What testing framework is used?**
 
-4.  Do you use any code health checking tools in your current workflow?
+**Do you use any code health checking tools in your current workflow?**
 
-5.  Did you receive peer reviews on your code base in the last three
-    months by someone outside of your organization?
+**Did you receive peer reviews on your code base in the last three months by someone outside of your organization?**
 
-6.  Do you use any automation tools to deploy your project? (e.g.
-    Ansible, Chef, Docker containers, etc.)
+**Do you use any automation tools to deploy your project? (e.g. Ansible, Chef, Docker containers, etc.)**
 
 Documentation
-=============
+-------------
 
-This section helps us understand the documentation culture within each
-cohort. Some teams may do this better than others, and these questions
-help us evaluate where each team is in terms of writing great
-documentation.
+This section helps us understand the documentation culture within each cohort.
+Some teams may do this better than others, and these questions help us evaluate where each team is in terms of writing great documentation.
 
-1.  Do all open source repositories have a README with an explanation of
-    what the project does and why?
+**Do all open source repositories have a README with an explanation of what the project does and why?**
 
-2.  Do any projects have a written, documented guide that explain how to
-    create a development environment?
+**Do any projects have a written, documented guide that explain how to create a development environment?**
 
 Miscellaneous
-=============
+-------------
 
-This can be any questions we think are worth asking but don’t fit into
-another category.
+This can be any questions we think are worth asking but don’t fit into another category.
 
-1.  What would need to happen for you to focus more on improving the
-    transparency and open source community of your project?
+**What would need to happen for you to focus more on improving the transparency and open source community of your project?**
 
-2.  What does success look like in a world where you have released your
-    project as open source?
+**What does success look like in a world where you have released your project as open source?**


### PR DESCRIPTION
I was having a lot of issues getting the asciidoc format filled in properly. I went ahead and converted it to Markdown using pandoc. 

I kept the asciidoc template in there but if we have both and make changes, it'll be tough to maintain both if we're frequently making changes. I'm personally in favor of sticking with markdown as it's much simpler and more widely used. What do y'all think? We're using markdown in the wiki already.